### PR TITLE
Add node creation via selector and remove branch button

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,6 @@
                 <div id="chat-input-area">
                     <input type="text" id="messageInput" placeholder="メッセージを入力..." />
                     <button id="sendBtn">送信</button>
-                    <button id="branchBtn">新しい話題として分岐</button>
                 </div>
             </div>
         </main>

--- a/styles.css
+++ b/styles.css
@@ -406,14 +406,6 @@ main {
     background: #0056b3;
 }
 
-#branchBtn {
-    background: #28a745;
-    color: white;
-}
-
-#branchBtn:hover {
-    background: #1e7e34;
-}
 
 .mindmap-node.root {
     background: linear-gradient(135deg, #28a745 0%, #1e7e34 100%);


### PR DESCRIPTION
## Summary
- Streamlined node creation workflow by integrating it into the node selector
- Removed redundant branch button from chat interface
- Cleaned up coordinate positioning code that was no longer needed

## Major Changes
### UI Improvements
- **Node Selector Enhancement**: Added "＋ 新しい話題を作成" option positioned directly after "---" 
- **Chat Interface Cleanup**: Removed "新しい話題として分岐" button to reduce clutter
- **Consistent UX**: Single point of entry for creating new topics

### Code Improvements
- **New Methods**: Implemented `showCreateNodeDialog()` and `createNewNode()`
- **Code Cleanup**: Removed all x/y coordinate positioning logic (unused)
- **Bug Fixes**: Fixed database connection issues in node creation
- **Simplified Architecture**: Eliminated `findNonOverlappingPosition()` and related positioning code

## Workflow Enhancement
The new user experience is more intuitive:
1. User selects "＋ 新しい話題を作成" from node selector dropdown
2. System prompts for topic title via dialog
3. New node is automatically created as child of current selection (or root if none)
4. User is seamlessly redirected to the new chat with initial message

## Test plan
- [x] Test node creation from selector dropdown
- [x] Verify proper parent-child relationships
- [x] Confirm automatic chat opening after creation
- [x] Test hierarchy level calculation
- [x] Verify removal of branch button functionality

🤖 Generated with [Claude Code](https://claude.ai/code)